### PR TITLE
fix percentDocumented value when requiredToBeDocumented is empty array

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -75,7 +75,7 @@ export function load(app: Application) {
 
 		const percentDocumented = expectedCount
 			? Math.floor((100 * actualCount) / expectedCount)
-			: 0;
+			: 100;
 
 		let color = app.options.getValue("coverageColor");
 		if (!color) {


### PR DESCRIPTION
if `requiredToBeDocumented` = [ ] then doc coverage percentage is 0.
