### PR TITLE
feat: add coverageLabel option to allow custom label text on the badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ and only report missing documentation if reflections covered by that option are 
 
 ## Options
 
+- `coverageLabel` - Define the label for the coverage badge. Defaults to 'document'.
 - `coverageColor` - Define the define the color of the coverage badge background. Defaults to a dynamic color depending on coverage percentage.
 
 Default colors/icon sourced from [esdoc-coverage-plugin](https://github.com/esdoc/esdoc-plugins/tree/master/esdoc-coverage-plugin)

--- a/index.ts
+++ b/index.ts
@@ -4,6 +4,7 @@ import { Application, ReflectionKind, Renderer, RendererEvent } from "typedoc";
 
 declare module "typedoc" {
 	export interface TypeDocOptionMap {
+		coverageLabel: string;
 		coverageColor: string;
 	}
 }
@@ -20,8 +21,8 @@ const svg = `
   <path fill="@color@" d="M64 0h4v20h-4z"/>
   <rect rx="3" width="104" height="20" fill="url(#a)"/>
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-    <text x="32" y="15" fill="#010101" fill-opacity=".3">document</text>
-    <text x="32" y="14">document</text>
+    <text x="32" y="15" fill="#010101" fill-opacity=".3">@label@</text>
+    <text x="32" y="14">@label@</text>
     <text x="84" y="15" fill="#010101" fill-opacity=".3">@ratio@</text>
     <text x="84" y="14">@ratio@</text>
   </g>
@@ -29,6 +30,12 @@ const svg = `
 `.trim();
 
 export function load(app: Application) {
+	app.options.addDeclaration({
+		name: "coverageLabel",
+		help: "Define the label for the coverage badge. Defaults to 'document'.",
+		defaultValue: "document",
+	});
+
 	app.options.addDeclaration({
 		name: "coverageColor",
 		help: "Define the define the color of the coverage badge background. Defaults to a dynamic color depending on coverage percentage.",
@@ -71,6 +78,7 @@ export function load(app: Application) {
 			? Math.floor((100 * actualCount) / expectedCount)
 			: 0;
 
+		let label = app.options.getValue("coverageLabel");
 		let color = app.options.getValue("coverageColor");
 		if (!color) {
 			if (percentDocumented < 50) {
@@ -84,7 +92,8 @@ export function load(app: Application) {
 
 		const badge = svg
 			.replace(/@ratio@/g, `${percentDocumented}%`)
-			.replace(/@color@/g, color);
+			.replace(/@color@/g, color)
+			.replace(/@label@/g, label);
 		writeFileSync(join(event.outputDirectory, "coverage.svg"), badge);
 	});
 }


### PR DESCRIPTION
This PR add `coverageLabel` to the plugin options to allow custom label text on the generated svg badge.

It should close #4 

Thanks