### PR TITLE
11 coverage label values overrun width of svg

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ and only report missing documentation if reflections covered by that option are 
 - `coverageColor` - Define the define the color of the coverage badge background. Defaults to a dynamic color depending on coverage percentage.
 - `coverageOutputPath` - Defines the path where the coverage badge will be written, defaults to `<output directory>/coverage.svg`.
 - `coverageOutputType` - Defines the type of the coverage file to be written ('svg', 'json', 'all'). Defaults to 'svg'.
+- `coverageSvgWidth` - Defines the width, in pixels, of the generated svg file.
 
 Default colors/icon sourced from [esdoc-coverage-plugin](https://github.com/esdoc/esdoc-plugins/tree/master/esdoc-coverage-plugin)
 

--- a/index.ts
+++ b/index.ts
@@ -72,7 +72,7 @@ const svg = (color: string, label: string, ratio: number, width: number) => {
   </g>
 </svg>
 `.trim();
-}
+};
 
 export function load(app: Application) {
 	app.options.addDeclaration({

--- a/index.ts
+++ b/index.ts
@@ -43,7 +43,7 @@ declare module "typedoc" {
 	}
 }
 
-const svg = (color: string, label: string, ratio: number, width: number = 104) => {
+const svg = (color: string, label: string, ratio: number, width: number) => {
 	const ratioGapWidth = 20;
 	const ratioRectWidth = 40;
 	const ratioRectX = width - ratioRectWidth;
@@ -105,6 +105,7 @@ export function load(app: Application) {
 		name: "coverageSvgWidth",
 		help: "Defines the width, in pixels, of the generated svg file.",
 		type: ParameterType.Number,
+		defaultValue: 104,
 	});
 
 	app.renderer.on(Renderer.EVENT_END, (event: RendererEvent) => {

--- a/index.ts
+++ b/index.ts
@@ -39,28 +39,40 @@ declare module "typedoc" {
 		coverageOutputPath: string;
 		coverageDebug: boolean;
 		coverageOutputType: CoverageOutputType;
+		coverageSvgWidth: number;
 	}
 }
 
-const svg = `
-<svg xmlns="http://www.w3.org/2000/svg" width="104" height="20">
+const svg = (color: string, label: string, ratio: number, width: number = 104) => {
+	const ratioGapWidth = 20;
+	const ratioRectWidth = 40;
+	const ratioRectX = width - ratioRectWidth;
+	const ratioTextX = ratioRectX + ratioGapWidth;
+
+	return `
+<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="20">
   <script/>
   <linearGradient id="a" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
     <stop offset="1" stop-opacity=".1"/>
   </linearGradient>
-  <rect rx="3" width="104" height="20" fill="#555"/>
-  <rect rx="3" x="64" width="40" height="20" fill="@color@"/>
-  <path fill="@color@" d="M64 0h4v20h-4z"/>
-  <rect rx="3" width="104" height="20" fill="url(#a)"/>
-  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-    <text x="32" y="15" fill="#010101" fill-opacity=".3">@label@</text>
-    <text x="32" y="14">@label@</text>
-    <text x="84" y="15" fill="#010101" fill-opacity=".3">@ratio@</text>
-    <text x="84" y="14">@ratio@</text>
+  <rect rx="3" width="${width}" height="20" fill="#555"/>
+  <rect rx="3" x="${ratioRectX}" width="${ratioRectWidth}" height="20" fill="${color}"/>
+  <path fill="${color}" d="M${ratioRectX} 0h4v20h-4z"/>
+  <rect rx="3" width="${width}" height="20" fill="url(#a)"/>
+  <g fill="#fff" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+    <g text-anchor="left">
+      <text x="5" y="15" fill="#010101" fill-opacity=".3">${label}</text>
+      <text x="5" y="14">${label}</text>
+    </g>
+    <g text-anchor="middle">
+      <text x="${ratioTextX}" y="15" fill="#010101" fill-opacity=".3">${ratio}%</text>
+      <text x="${ratioTextX}" y="14">${ratio}%</text>
+    </g>
   </g>
 </svg>
 `.trim();
+}
 
 export function load(app: Application) {
 	app.options.addDeclaration({
@@ -87,6 +99,12 @@ export function load(app: Application) {
 		type: ParameterType.Map,
 		map: CoverageOutputType,
 		defaultValue: CoverageOutputType.svg,
+	});
+
+	app.options.addDeclaration({
+		name: "coverageSvgWidth",
+		help: "Defines the width, in pixels, of the generated svg file.",
+		type: ParameterType.Number,
 	});
 
 	app.renderer.on(Renderer.EVENT_END, (event: RendererEvent) => {
@@ -219,10 +237,8 @@ export function load(app: Application) {
 			}
 		}
 
-		const badge = svg
-			.replace(/@ratio@/g, `${percentDocumented}%`)
-			.replace(/@color@/g, color)
-			.replace(/@label@/g, label);
+		const width = app.options.getValue("coverageSvgWidth");
+		const badge = svg(color, label, percentDocumented, width);
 		const outFile =
 			app.options.getValue("coverageOutputPath") ||
 			join(event.outputDirectory, "coverage.svg");


### PR DESCRIPTION
I opted to only provide a new `coverageSvgWidth` option. The changes are laid out in detail in the main commit, but here are the highlights:

- handling all the svg attributes (calculating widths and x-coordinates) meant transforming `svg` from a variable to a function
- the new option uses the existing width value as a default, so running the plugin without the new option should result in no visible changes (there are small changes to the overall svg markup)
- added the new option to `README.md`
- tests still pass
- the `index.ts` file contained mostly tabs for indentation, but used spaces within the svg markup. I think I maintained that style correctly, but also let me know if I've made a mess of it

Sample output:

![image](https://github.com/user-attachments/assets/54f4a79a-d159-41b6-ba25-df5ae6915ba8)


