### PR TITLE
changes undocumented extension behavior on output all

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -249,11 +249,12 @@ export function load(app: Application) {
 		const outFile = app.options.getValue("coverageOutputPath")
 			|| join(event.outputDirectory, "coverage.svg");
 		const { dir, name } = parse(outFile);
+		const outFileSvg = join(dir, `${name}.svg`);
 		const outFileJson = join(dir, `${name}.json`);
 		const outputType = app.options.getValue("coverageOutputType");
 		switch (outputType) {
 			case CoverageOutputType.svg:
-				writeFileSync(outFile, badge);
+				writeFileSync(outFileSvg, badge);
 				break;
 			case CoverageOutputType.json:
 				writeFileSync(
@@ -276,7 +277,7 @@ export function load(app: Application) {
 						notDocumented,
 					}),
 				);
-				writeFileSync(outFile, badge);
+				writeFileSync(outFileSvg, badge);
 				break;
 			default:
 				// This should never happen, but just in case.

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,5 @@
 import { writeFileSync } from "fs";
-import { join } from "path";
+import { join, parse } from "path";
 import {
 	Application,
 	DeclarationReflection,
@@ -248,7 +248,8 @@ export function load(app: Application) {
 		const badge = svg(color, label, percentDocumented, width);
 		const outFile = app.options.getValue("coverageOutputPath")
 			|| join(event.outputDirectory, "coverage.svg");
-		const outFileJson = outFile.replace(/\.svg$/, ".json");
+		const { dir, name } = parse(outFile);
+		const outFileJson = join(dir, `${name}.json`);
 		const outputType = app.options.getValue("coverageOutputType");
 		switch (outputType) {
 			case CoverageOutputType.svg:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "typedoc-plugin-coverage",
-	"version": "4.0.3",
+	"version": "4.0.2",
 	"type": "module",
 	"exports": "./index.js",
 	"license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "typedoc-plugin-coverage",
-	"version": "4.0.2",
+	"version": "4.0.3",
 	"type": "module",
 	"exports": "./index.js",
 	"license": "MIT",

--- a/test/packages.test.ts
+++ b/test/packages.test.ts
@@ -1,10 +1,11 @@
+import { existsSync } from "fs";
 import { mkdtemp, readFile, rm } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
 import { Application, TSConfigReader, TypeDocOptions } from "typedoc";
 import * as ts from "typescript";
 import { beforeAll, describe, expect, it } from "vitest";
-import { load } from "../index.js";
+import { CoverageOutputType, load } from "../index.js";
 
 let app: Application;
 let program: ts.Program;
@@ -94,6 +95,46 @@ describe("Plugin", () => {
 		await expectCoverage(1 / 1, "functions", {
 			requiredToBeDocumented: ["Project"],
 		});
+	});
+
+	it("Writes both SVG and JSON for output type 'all' with custom path", async () => {
+		const sf = program.getSourceFile(
+			join(__dirname, "packages", "functions", "index.ts"),
+		);
+		expect(sf).toBeDefined();
+
+		const tmp = await mkdtemp(join(tmpdir(), "typedoc-plugin-coverage-"));
+		const customPath = join(tmp, "my-badge.custom");
+
+		const snapshot = app.options.snapshot();
+		try {
+			app.options.setValue("coverageOutputType", CoverageOutputType.all);
+			app.options.setValue("coverageOutputPath", customPath);
+
+			const project = app.converter.convert([
+				{
+					displayName: "functions",
+					program,
+					sourceFile: sf!,
+				},
+			]);
+			await app.renderer.render(project, tmp);
+
+			expect(existsSync(customPath)).toBe(true);
+			const svgContent = await readFile(customPath, "utf-8");
+			expect(svgContent).toContain("<svg");
+
+			const jsonPath = join(tmp, "my-badge.json");
+			expect(existsSync(jsonPath)).toBe(true);
+			const jsonContent = JSON.parse(await readFile(jsonPath, "utf-8"));
+			expect(jsonContent).toHaveProperty("percent");
+			expect(jsonContent).toHaveProperty("expected");
+			expect(jsonContent).toHaveProperty("actual");
+			expect(jsonContent).toHaveProperty("notDocumented");
+		} finally {
+			app.options.restore(snapshot);
+			await rm(tmp, { recursive: true, force: true });
+		}
 	});
 
 	it("Respects packagesRequiringDocumentation", async () => {


### PR DESCRIPTION
At this time the extension behavior in `coverageOutputType` is undocumented, and was to me counterintuitive.

Prior, this regex searched the output filename for `.svg`, and swapped it out with `.json` for the second write.

Problem is, I started with JSON, not SVG, so my output filename was `.json`, which with the old logic ended up with the file being overwritten with svg contents.

Then I tried no extension.  Same result.

New logic:

1. Uses `node:fs` filename splitting to separate the extension
2. Handles the no-extension case correctly
3. Ignores the extension given and outputs what it perfectly well feels like

This correctly handles all old users and both mistake cases I'm able to think of, transparently

A test case was added to verify that this works