### PR TITLE
Fix `tests` directory not being typechecked

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"typedoc": "0.28.x"
 	},
 	"scripts": {
-		"test": "vitest run",
+		"test": "vitest run && tsc -p test",
 		"build": "tsc",
 		"lint": "dprint check"
 	},

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    // NB: We cannot use project references for this as it requires enabling declaration emit,
+    // and the entire reason for having 2 TSConfigs is to avoid said declaration emit
+    "extends": "../tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+    },
+    "include": ["."],
+    "exclude": ["packages"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,4 @@
 		"skipLibCheck": true
 	},
 	"files": ["index.ts"],
-	"exclude": ["test/packages"]
 }


### PR DESCRIPTION
As a comment on PR #18 describes, we previously did not check for type errors inside `test` during CI.
Now we do.